### PR TITLE
Cf add industry by subject dropdown

### DIFF
--- a/R/industry_flow.R
+++ b/R/industry_flow.R
@@ -13,8 +13,6 @@ sankey_chart <- function(subjectinput, sexinput, qualinput) {
   cohort_sankey1 <- na.omit(cohort_sankey1)
   cohort_sankey2 <- na.omit(cohort_sankey2)
 
- 
-
   # Choose top 9 SIC section names and label all others as 'OTHER' based on counts for 1 YAG
 
   section_names1 <- cohort_sankey1 %>%

--- a/R/industry_flow.R
+++ b/R/industry_flow.R
@@ -13,27 +13,7 @@ sankey_chart <- function(subjectinput, sexinput, qualinput) {
   cohort_sankey1 <- na.omit(cohort_sankey1)
   cohort_sankey2 <- na.omit(cohort_sankey2)
 
-  # quick table code
-  # 1 YAG
-  one_yag_table <- cohort_sankey1 %>%
-    group_by(YAG.x, SECTIONNAME.x) %>%
-    dplyr::summarise(count = sum(count))
-  one_yag_table <- one_yag_table %>%
-    mutate("1 YAG" = count / sum(count))
-
-  # 3 YAG
-  three_yag_table <- cohort_sankey1 %>%
-    group_by(YAG.y, SECTIONNAME.y) %>%
-    dplyr::summarise(count = sum(count))
-  three_yag_table <- three_yag_table %>%
-    mutate("3 YAG" = count / sum(count))
-
-  # 5 YAG
-  five_yag_table <- cohort_sankey2 %>%
-    group_by(YAG.y, SECTIONNAME.y) %>%
-    dplyr::summarise(count = sum(count))
-  five_yag_table <- five_yag_table %>%
-    mutate("5 YAG" = count / sum(count))
+ 
 
   # Choose top 9 SIC section names and label all others as 'OTHER' based on counts for 1 YAG
 

--- a/R/industry_subject.R
+++ b/R/industry_subject.R
@@ -329,9 +329,6 @@ downloadcrosstabs <- function(subjectinput, YAGinput, countinput, qualinput) {
 backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, buttoninput, groupinput) {
   tables_data$SECTIONNAME[is.na(tables_data$SECTIONNAME) == TRUE] <- "NOT KNOWN"
 
-  # tables_data <- tables_data %>%
-  #   filter(group_name == "All")
-
   orange_pal <- function(x) {
     if (!is.na(x)) {
       rgb(colorRamp(c("#F7FBFF", "#2F75B5"))(x), maxColorValue = 255)

--- a/R/industry_subject.R
+++ b/R/industry_subject.R
@@ -327,7 +327,6 @@ downloadcrosstabs <- function(subjectinput, YAGinput, countinput, qualinput) {
 
 
 backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, buttoninput, groupinput) {
-
   tables_data$SECTIONNAME[is.na(tables_data$SECTIONNAME) == TRUE] <- "NOT KNOWN"
 
   # tables_data <- tables_data %>%

--- a/R/industry_subject.R
+++ b/R/industry_subject.R
@@ -385,7 +385,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(ethnicity, subject_name) %>%
-      summarise(n = earnings_median) %>%
+      summarise(n = earnings_median, .groups = "drop") %>%
       spread(ethnicity, n) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(. == 0, NA, .))) %>%
@@ -444,7 +444,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(current_region, subject_name) %>%
-      summarise(n = sum(count), .groups = "drop") %>%
+      summarise(n = count, .groups = "drop") %>%
       spread(current_region, n) %>%
       arrange(-All) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%
@@ -472,7 +472,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(current_region, subject_name) %>%
-      summarise(n = earnings_median) %>%
+      summarise(n = earnings_median, .groups = "drop") %>%
       spread(current_region, n) %>%
       arrange(-All) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%

--- a/R/industry_subject.R
+++ b/R/industry_subject.R
@@ -571,7 +571,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(FSM, subject_name) %>%
-      summarise(n = earnings_median) %>%
+      summarise(n = earnings_median, .groups = "drop") %>%
       spread(FSM, n) %>%
       arrange(-All) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%
@@ -651,7 +651,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(sex, subject_name) %>%
-      summarise(n = earnings_median) %>%
+      summarise(n = earnings_median, .groups = "drop") %>%
       spread(sex, n) %>%
       arrange(-`F+M`) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%
@@ -733,7 +733,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(prior_attainment, subject_name) %>%
-      summarise(n = earnings_median) %>%
+      summarise(n = earnings_median, .groups = "drop") %>%
       spread(prior_attainment, n) %>%
       arrange(-All) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%
@@ -819,7 +819,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(SECTIONNAME, subject_name) %>%
-      summarise(n = earnings_median) %>%
+      summarise(n = earnings_median, .groups = "drop") %>%
       spread(SECTIONNAME, n) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(. == 0, NA, .))) %>%
@@ -897,7 +897,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
         group_name %in% c(groupinput)
       ) %>%
       group_by(qualification_TR, subject_name) %>%
-      summarise(n = earnings_median) %>%
+      summarise(n = earnings_median, .groups = "drop") %>%
       spread(qualification_TR, n) %>%
       arrange(-`First degree`) %>%
       mutate_at(vars(-group_cols()), funs(ifelse(is.na(.), 0, .))) %>%

--- a/R/industry_subject.R
+++ b/R/industry_subject.R
@@ -366,7 +366,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, FSM == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(ethnicity, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -386,7 +386,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, FSM == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(ethnicity, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -419,7 +419,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, FSM == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == "First degree", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(ethnicity, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -445,7 +445,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(current_region, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -473,7 +473,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(current_region, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -513,7 +513,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(current_region, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -551,7 +551,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(FSM, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -572,7 +572,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(FSM, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -605,7 +605,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(FSM, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -629,7 +629,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All", FSM == "All",
         prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(sex, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -652,7 +652,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All", FSM == "All",
         prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(sex, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -688,7 +688,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All", FSM == "All",
         prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(sex, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -712,7 +712,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(prior_attainment, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -734,7 +734,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(prior_attainment, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -768,7 +768,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(prior_attainment, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -805,7 +805,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", YAG == YAGinput, ethnicity == "All", FSM == "All", current_region == "All", prior_attainment == "All",
         qualification_TR == qualinput, threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(SECTIONNAME, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -820,7 +820,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", YAG == YAGinput, ethnicity == "All", FSM == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == qualinput, threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(SECTIONNAME, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -848,7 +848,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", YAG == YAGinput, ethnicity == "All", FSM == "All", current_region == "All",
         prior_attainment == "All", qualification_TR == qualinput, threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(SECTIONNAME, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -882,7 +882,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(qualification_TR, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -898,7 +898,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(qualification_TR, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -927,7 +927,7 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
         current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All",
-        group_name == groupinput
+        group_name %in% c(groupinput)
       ) %>%
       group_by(qualification_TR, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%

--- a/R/industry_subject.R
+++ b/R/industry_subject.R
@@ -326,15 +326,12 @@ downloadcrosstabs <- function(subjectinput, YAGinput, countinput, qualinput) {
 }
 
 
-backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, buttoninput) {
-
-  # tables_data <- tables_data %>%
-  #   filter(subject_name != 'All')
+backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, buttoninput, groupinput) {
 
   tables_data$SECTIONNAME[is.na(tables_data$SECTIONNAME) == TRUE] <- "NOT KNOWN"
 
-  tables_data <- tables_data %>%
-    filter(group_name == "All")
+  # tables_data <- tables_data %>%
+  #   filter(group_name == "All")
 
   orange_pal <- function(x) {
     if (!is.na(x)) {
@@ -368,7 +365,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, FSM == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(ethnicity, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -387,7 +385,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_earnings_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, FSM == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(ethnicity, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -419,7 +418,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     footer_data <- footerdata %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, FSM == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == "First degree", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(ethnicity, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -444,7 +444,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(current_region, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -471,7 +472,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_earnings_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(current_region, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -510,7 +512,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     footer_data <- footerdata %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(current_region, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -547,7 +550,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(FSM, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -567,7 +571,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_earnings_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(FSM, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -599,7 +604,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     footer_data <- footerdata %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(FSM, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -622,7 +628,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_data <- tables_data %>%
       filter(
         SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All", FSM == "All",
-        prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(sex, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -644,7 +651,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_earnings_data <- tables_data %>%
       filter(
         SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All", FSM == "All",
-        prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(sex, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -679,7 +687,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     footer_data <- footerdata %>%
       filter(
         SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", current_region == "All", FSM == "All",
-        prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All"
+        prior_attainment == "All", qualification_TR == qualinput, subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(sex, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -702,7 +711,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(prior_attainment, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -723,7 +733,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_earnings_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(prior_attainment, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -756,7 +767,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     footer_data <- footerdata %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All"
+        current_region == "All", qualification_TR == "First degree", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(prior_attainment, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -792,7 +804,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_data <- tables_data %>%
       filter(
         sex == "F+M", YAG == YAGinput, ethnicity == "All", FSM == "All", current_region == "All", prior_attainment == "All",
-        qualification_TR == qualinput, threshold == "All"
+        qualification_TR == qualinput, threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(SECTIONNAME, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -806,7 +819,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_earnings_data <- tables_data %>%
       filter(
         sex == "F+M", YAG == YAGinput, ethnicity == "All", FSM == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == qualinput, threshold == "All"
+        prior_attainment == "All", qualification_TR == qualinput, threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(SECTIONNAME, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -833,7 +847,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     footer_data <- footerdata %>%
       filter(
         sex == "F+M", YAG == YAGinput, ethnicity == "All", FSM == "All", current_region == "All",
-        prior_attainment == "All", qualification_TR == qualinput, threshold == "All"
+        prior_attainment == "All", qualification_TR == qualinput, threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(SECTIONNAME, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -866,7 +881,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All"
+        current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(qualification_TR, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%
@@ -881,7 +897,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     crosstabs_earnings_data <- tables_data %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All"
+        current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(qualification_TR, subject_name) %>%
       summarise(n = earnings_median) %>%
@@ -909,7 +926,8 @@ backwards_crosstabs <- function(sectioninput, YAGinput, countinput, qualinput, b
     footer_data <- footerdata %>%
       filter(
         sex == "F+M", SECTIONNAME == sectioninput, YAG == YAGinput, ethnicity == "All", FSM == "All",
-        current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All"
+        current_region == "All", prior_attainment == "All", subject_name != "All", threshold == "All",
+        group_name == groupinput
       ) %>%
       group_by(qualification_TR, subject_name) %>%
       summarise(n = sum(count), .groups = "drop") %>%

--- a/global.R
+++ b/global.R
@@ -62,3 +62,7 @@ tables_data <- read_tables_data("data/pg_sic_crosstabs_earnings_data_cf_dummy.cs
 qual_subjects <- tables_data %>%
   select(qualification_TR, subject_name) %>%
   distinct()
+
+industry_groups <- tables_data %>%
+  select(SECTIONNAME, group_name) %>%
+  distinct()

--- a/server.R
+++ b/server.R
@@ -226,8 +226,8 @@ server <- function(input, output, session) {
       choices = unique(c("All", data_filtered$group_name))
     )
   })
-  
-  
+
+
   # output$subjecttable <- renderReactable({
   #   subjecttable(input$sectionnameinput2, input$YAGinput3, input$countinput3)
   # })

--- a/server.R
+++ b/server.R
@@ -170,7 +170,7 @@ server <- function(input, output, session) {
   })
 
   reactiveIndSubjTable <- reactive({
-    backwards_crosstabs(input$sectionnameinput2, input$YAGinput3, input$countinput3, input$qualinput4, input$earningsbutton2)
+    backwards_crosstabs(input$sectionnameinput2, input$YAGinput3, input$countinput3, input$qualinput4, input$earningsbutton2, input$groupinput)
   })
   output$crosstab_backwards <- renderReactable({
     reactiveIndSubjTable()
@@ -213,6 +213,21 @@ server <- function(input, output, session) {
     )
   })
 
+  observe({
+    if (input$sectionnameinput != "All") {
+      data_filtered <- industry_groups %>%
+        filter(SECTIONNAME == input$sectionnameinput2) %>%
+        distinct()
+    } else {
+      data_filtered <- industry_groups
+    }
+    updateSelectizeInput(
+      session, "groupinput",
+      choices = unique(c("All", data_filtered$group_name))
+    )
+  })
+  
+  
   # output$subjecttable <- renderReactable({
   #   subjecttable(input$sectionnameinput2, input$YAGinput3, input$countinput3)
   # })

--- a/ui.R
+++ b/ui.R
@@ -586,6 +586,18 @@ fluidPage(
               selected = "Education"
             )
           ),
+          
+          ### Group input -----------------------------------------------------
+          
+          conditionalPanel(
+            condition = "input.countinput3 != 'SECTIONNAME'",
+            selectizeInput("groupinput",
+                        label = "View 3-digit SIC groups within the selected industry",
+                        choices = unique(c("All", sort(industry_groups$group_name))),
+                        selected = "All", multiple = FALSE
+            )
+          ),
+        
 
           ### Breakdown input -------------------------------------------------
 

--- a/ui.R
+++ b/ui.R
@@ -586,18 +586,18 @@ fluidPage(
               selected = "Education"
             )
           ),
-          
+
           ### Group input -----------------------------------------------------
-          
+
           conditionalPanel(
             condition = "input.countinput3 != 'SECTIONNAME'",
             selectizeInput("groupinput",
-                        label = "View 3-digit SIC groups within the selected industry",
-                        choices = unique(c("All", sort(industry_groups$group_name))),
-                        selected = "All", multiple = FALSE
+              label = "View 3-digit SIC groups within the selected industry",
+              choices = unique(c("All", sort(industry_groups$group_name))),
+              selected = "All", multiple = FALSE
             )
           ),
-        
+
 
           ### Breakdown input -------------------------------------------------
 


### PR DESCRIPTION
## Pull request overview

Add extra dropdown to the industry by subject tables, close #42.

## Pull request checklist

Please check if your PR fulfils the following:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the new behaviour?

A new dropdown has been added to the industry by subject tables that allows users to filter the tables further - to the 3-digit SIC group level rather than just the SECTIONNAME level. The dropdown updates based on the selected SECTIONNAME to only include the appropriate group_names. 
![image](https://user-images.githubusercontent.com/101197790/163181660-404f4b0b-63f5-4410-9d29-1d8a5729fe2b.png)

## Anything else

@rmbielby to look at allowing multiple selections at a later date.
