### PR TITLE
copy CSS styling to regional table tab

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -417,26 +417,28 @@ fluidPage(
               div(
                 # Set as well but override sidebar defaults
                 class = "well",
-                style = "height: 100%; overflow-y: visible",
+                style = "min-height: 100%; height: 100%; overflow-y: visible",
 
                 #### Regional input -------------------------------------------
 
-                div(selectizeInput("regioninput",
-                  label = "Select multiple regions from the dropdown below to compare.",
-                  choices = list(
-                    "North East",
-                    "North West",
-                    "Yorkshire and the Humber",
-                    "East Midlands",
-                    "West Midlands",
-                    "East of England",
-                    "London",
-                    "South East",
-                    "South West"
-                  ),
-                  selected = "London", multiple = FALSE,
-                  options = list(maxItems = 9, placeholder = "Start typing a region")
-                ))
+                div(
+                  selectizeInput("regioninput",
+                    label = "Select multiple regions from the dropdown below to compare.",
+                    choices = list(
+                      "North East",
+                      "North West",
+                      "Yorkshire and the Humber",
+                      "East Midlands",
+                      "West Midlands",
+                      "East of England",
+                      "London",
+                      "South East",
+                      "South West"
+                    ),
+                    selected = "London", multiple = FALSE,
+                    options = list(maxItems = 9, placeholder = "Start typing a region")
+                  )
+                )
               ),
 
               #### Table ------------------------------------------------------


### PR DESCRIPTION
## Pull request overview

Quick one - update the styling override so the blue box is only the size of the input box.

Before:

![image](https://user-images.githubusercontent.com/52536248/167868320-c43d7ae7-aaf8-4d33-b2b5-72a14e707c67.png)

After:

![image](https://user-images.githubusercontent.com/52536248/167868162-2b329650-d22d-40a5-92a5-e07563d254ee.png)

## Pull request checklist

Please check if your PR fulfils the following:
- [ N/A ] Tests for the changes have been added (for bug fixes / features)
- [ N/A ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ Yes ] Tests have been run locally and are passing (`run_tests_locally()`)
- [ Yes ] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)
