### PR TITLE
Remove sankey flag

### DIFF
--- a/R/industry_flow.R
+++ b/R/industry_flow.R
@@ -502,19 +502,20 @@ sankeytext2 <- function(subjectinput, sexinput, qualinput) {
 
   cohort_sankey2_text$count <- prettyNum(cohort_sankey2_text$count, big.mark = ",", scientific = FALSE)
 
-  if(first(cohort_sankey1_text$count) == 0){
-    sankeytext2 <- ''
-  } else if(first(cohort_sankey2_text$count)==0){
-    sankeytext2 <- ''
+  if (first(cohort_sankey1_text$count) == 0) {
+    sankeytext2 <- ""
+  } else if (first(cohort_sankey2_text$count) == 0) {
+    sankeytext2 <- ""
   } else {
-  sankeytext2 <- paste(
-    "The most movement between one and three years after graduation is seen for <b>",
-    first(cohort_sankey1_text$SECTIONNAME.x), "</b>, where </b>", first(cohort_sankey1_text$count),
-    " graduates move to <b>", first(cohort_sankey1_text$SECTIONNAME.y), "</b>. Between three and five
+    sankeytext2 <- paste(
+      "The most movement between one and three years after graduation is seen for <b>",
+      first(cohort_sankey1_text$SECTIONNAME.x), "</b>, where </b>", first(cohort_sankey1_text$count),
+      " graduates move to <b>", first(cohort_sankey1_text$SECTIONNAME.y), "</b>. Between three and five
                        years after graduation it's seen for <b>", first(cohort_sankey2_text$SECTIONNAME.x), "</b> where <b>",
-    first(cohort_sankey2_text$count), "</b> graduates moved to <b>", first(cohort_sankey2_text$SECTIONNAME.y),
-    "</b>."
-  )}
+      first(cohort_sankey2_text$count), "</b> graduates moved to <b>", first(cohort_sankey2_text$SECTIONNAME.y),
+      "</b>."
+    )
+  }
 
   return(sankeytext2)
 }

--- a/R/support_links.R
+++ b/R/support_links.R
@@ -5,9 +5,9 @@ support_links <- function() {
     a(
       href = "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-c6JT6ONG3lJtlg-5hU4A6xURUpQME1OUVZIMEFMUUdNMEVONkhEN0g1VSQlQCN0PWcu",
       "feedback form", .noWS = c("after")
-    ), ".",br(),
+    ), ".", br(),
     "If you spot any errors or bugs while using this dashboard, please screenshot and email them to ",
-    a(href = "mailto:he.leo@education.gov.uk", "he.leo@education.gov.uk", .noWS = c("after")),".",
+    a(href = "mailto:he.leo@education.gov.uk", "he.leo@education.gov.uk", .noWS = c("after")), ".",
     br(),
     h2("Find more information on the data"),
     "The data used to produce the dashboard, along with methodological information can be found on ",

--- a/R/support_links.R
+++ b/R/support_links.R
@@ -5,8 +5,8 @@ support_links <- function() {
     a(
       href = "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-c6JT6ONG3lJtlg-5hU4A6xURUpQME1OUVZIMEFMUUdNMEVONkhEN0g1VSQlQCN0PWcu",
       "feedback form", .noWS = c("after")
-    ),br(),
-    ". If you spot any errors or bugs while using this dashboard, please screenshot and email them to ",
+    ), ".",br(),
+    "If you spot any errors or bugs while using this dashboard, please screenshot and email them to ",
     a(href = "mailto:he.leo@education.gov.uk", "he.leo@education.gov.uk", .noWS = c("after")),".",
     br(),
     h2("Find more information on the data"),

--- a/ui.R
+++ b/ui.R
@@ -224,18 +224,18 @@ fluidPage(
                 4,
                 div("5 years after graduation", style = "text-align: right")
               ),
-              conditionalPanel(
-                condition = "!is.null(output$sankey_flag)",
+             # conditionalPanel(
+             #   condition = "!is.null(output$sankey_flag)",
                 withSpinner(
                   uiOutput("sankey_flag")
-                )
+             #   )
               ),
-              conditionalPanel(
-                condition = "is.null(output$sankey_flag)",
+             # conditionalPanel(
+              #  condition = "is.null(output$sankey_flag)",
                 withSpinner(
                   sankeyNetworkOutput(outputId = "sankey", height = 800)
                 )
-              )
+             # )
             ),
 
             #### Table --------------------------------------------------------

--- a/ui.R
+++ b/ui.R
@@ -40,14 +40,13 @@ fluidPage(
 
     tabPanel(
       value = "homepage", title = "Homepage",
-
       noti_banner(
         "notId",
         title_txt = "Known issue",
         body_txt = "We are aware of and working to address performance issues with the dashboard, during this time some interactive elements may be slow.",
         type = "standard"
       ),
-      
+
       ## Tab content ----------------------------------------------------------
 
       fluidPage(
@@ -224,18 +223,18 @@ fluidPage(
                 4,
                 div("5 years after graduation", style = "text-align: right")
               ),
-             # conditionalPanel(
-             #   condition = "!is.null(output$sankey_flag)",
-                withSpinner(
-                  uiOutput("sankey_flag")
-             #   )
+              # conditionalPanel(
+              #   condition = "!is.null(output$sankey_flag)",
+              withSpinner(
+                uiOutput("sankey_flag")
+                #   )
               ),
-             # conditionalPanel(
+              # conditionalPanel(
               #  condition = "is.null(output$sankey_flag)",
-                withSpinner(
-                  sankeyNetworkOutput(outputId = "sankey", height = 800)
-                )
-             # )
+              withSpinner(
+                sankeyNetworkOutput(outputId = "sankey", height = 800)
+              )
+              # )
             ),
 
             #### Table --------------------------------------------------------

--- a/ui.R
+++ b/ui.R
@@ -225,10 +225,10 @@ fluidPage(
               ),
               # conditionalPanel(
               #   condition = "!is.null(output$sankey_flag)",
-              withSpinner(
-                uiOutput("sankey_flag")
-                #   )
-              ),
+              # withSpinner(
+              #  uiOutput("sankey_flag")
+              #   )
+              # ),
               # conditionalPanel(
               #  condition = "is.null(output$sankey_flag)",
               withSpinner(


### PR DESCRIPTION
## Pull request overview

We're having a weird performance issue on the deployed app, where chrome and edge are significantly slower that safari for loading interactive elements. Seems like some other people have had a similar difference in browser behaviour and recommended investigating the browser console errors.

Previously we were getting a number of errors in the browser console around the sankey flag for the industry flow tab.

![image](https://user-images.githubusercontent.com/52536248/168062765-409be486-9452-4720-b83d-f5c9e3e1ba0b.png)

Removing the flag and conditional panels seems to prevent these errors locally, so raising this PR to try to see if it will have any impact on the deployed app.

This does mean that there's no neat handling of the sankey where there's no data (e.g. Celtic studies), though figure it's worth trying this now and then adding that improvement back in later.

## Pull request checklist

Please check if your PR fulfils the following:
- [ No ] Tests for the changes have been added (for bug fixes / features)
- [ No ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ Yes ] Tests have been run locally and are passing (`run_tests_locally()`)
- [ Yes ] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)