### PR TITLE
Fix dropdowns

### DIFF
--- a/server.R
+++ b/server.R
@@ -368,34 +368,6 @@ server <- function(input, output, session) {
     paste(a(h4("How to read this sankey?")))
   })
 
-  observe({
-    if (input$qualinput3 != "All") {
-      data_filtered <- qual_subjects %>%
-        filter(qualification_TR == input$qualinput3) %>%
-        distinct()
-    } else {
-      data_filtered <- qual_subjects
-    }
-    updateSelectInput(
-      session, "crosstabs.subjectinput",
-      choices = unique(c("All", data_filtered$subject_name))
-    )
-  })
-
-  observe({
-    if (input$sectionnameinput2 != "All") {
-      data_filtered <- industry_groups %>%
-        filter(SECTIONNAME == input$sectionnameinput2) %>%
-        distinct()
-    } else {
-      data_filtered <- industry_groups
-    }
-    updateSelectizeInput(
-      session, "groupinput",
-      choices = unique(c("All", data_filtered$group_name))
-    )
-  })
-
   # Conditional panel replacements ####
 
   # Qualification input condition (sub by ind) ----
@@ -430,6 +402,20 @@ server <- function(input, output, session) {
 
   # Subject input condition (sub by ind) ----
 
+  observeEvent(input$qualinput3, {
+    if (input$qualinput3 != "All") {
+      data_filtered <- qual_subjects %>%
+        filter(qualification_TR == input$qualinput3) %>%
+        distinct()
+    } else {
+      data_filtered <- qual_subjects
+    }
+    updateSelectInput(
+      session, "crosstabs.subjectinput",
+      choices = na.exclude(unique(c("All", data_filtered$subject_name)))
+    )
+  })
+
   observeEvent(input$countinput2, {
     x <- input$countinput2
 
@@ -444,12 +430,16 @@ server <- function(input, output, session) {
         selected = "All"
       )
     } else {
+      if (input$qualinput3 != "All") {
+        data_filtered <- qual_subjects %>%
+          filter(qualification_TR == input$qualinput3) %>%
+          distinct()
+      } else {
+        data_filtered <- qual_subjects
+      }
       updateSelectInput(
-        session,
-        "crosstabs.subjectinput",
-        label = "Select a subject area",
-        choices = unique(c("All", sort(qual_subjects$subject_name))),
-        selected = "All"
+        session, "crosstabs.subjectinput",
+        choices = na.exclude(unique(c("All", data_filtered$subject_name)))
       )
     }
   })
@@ -534,6 +524,20 @@ server <- function(input, output, session) {
 
   # Group input condition (ind by sub) ----
 
+  observeEvent(input$sectionnameinput2, {
+    if (input$sectionnameinput2 != "All") {
+      data_filtered <- industry_groups %>%
+        filter(SECTIONNAME == input$sectionnameinput2) %>%
+        distinct()
+    } else {
+      data_filtered <- industry_groups
+    }
+    updateSelectizeInput(
+      session, "groupinput",
+      choices = na.exclude(unique(c("All", data_filtered$group_name)))
+    )
+  })
+
   observeEvent(input$countinput3, {
     x <- input$countinput3
 
@@ -548,12 +552,17 @@ server <- function(input, output, session) {
         selected = "All"
       )
     } else {
-      updateSelectInput(
-        session,
-        "groupinput",
+      if (input$sectionnameinput2 != "All") {
+        data_filtered <- industry_groups %>%
+          filter(SECTIONNAME == input$sectionnameinput2) %>%
+          distinct()
+      } else {
+        data_filtered <- industry_groups
+      }
+      updateSelectizeInput(
+        session, "groupinput",
         label = "View 3 digit SIC groups within the selected industry",
-        choices = unique(c("All", sort(industry_groups$group_name))),
-        selected = "All"
+        choices = na.exclude(unique(c("All", data_filtered$group_name)))
       )
     }
   })

--- a/ui.R
+++ b/ui.R
@@ -40,12 +40,12 @@ fluidPage(
 
     tabPanel(
       value = "homepage", title = "Homepage",
-      noti_banner(
-        "notId",
-        title_txt = "Known issue",
-        body_txt = "We are aware of and working to address performance issues with the dashboard, during this time some interactive elements may be slow.",
-        type = "standard"
-      ),
+      # noti_banner(
+      #   "notId",
+      #   title_txt = "Known issue",
+      #   body_txt = "We are aware of and working to address performance issues with the dashboard, during this time some interactive elements may be slow.",
+      #   type = "standard"
+      # ),
 
       ## Tab content ----------------------------------------------------------
 


### PR DESCRIPTION
## Pull request overview

Removing the performance banner that we had up this morning during the initial loading issues.

There was an issue in the industry by subject drop down inputs where the filtering of the SIC codes by industry was being overwritten by the switching off of SIC codes when industry was selected.

The app now has two observeEvent() functions that look for changes to either the breakdown or industry area inputs and then update the SIC dropdown accordingly, so you should be able to filter the SIC dropdown using the industry area dropdown, and this should continue working after switching the breakdown to industry and back to something else.

## Pull request checklist

Please check if your PR fulfils the following:
- [ No ] Tests for the changes have been added (for bug fixes / features)
- [ No ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ Yes ] Tests have been run locally and are passing (`run_tests_locally()`)
- [ Yes ] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)