### PR TITLE
Replace NaNs in download table with x's

### DIFF
--- a/server.R
+++ b/server.R
@@ -277,9 +277,10 @@ server <- function(input, output, session) {
       dfDownload <- dfDownload %>%
         mutate_if(is.numeric, list(~ gsub(" ", "", format(., scientific = FALSE)))) %>%
         mutate_all(list(~ gsub("-10000", "c", .))) %>%
-        mutate_all(list(~ ifelse(. == "NA", "x", .))) %>%
+        mutate_all(list(~ ifelse(. %in% c("NA","NaN"), "x", .))) %>%
         arrange(SECTIONNAME, group_name) %>%
         rbind(footsum)
+      print(dfDownload)
       write.csv(dfDownload, file, row.names = FALSE)
     }
   )

--- a/server.R
+++ b/server.R
@@ -280,7 +280,6 @@ server <- function(input, output, session) {
         mutate_all(list(~ ifelse(. %in% c("NA","NaN"), "x", .))) %>%
         arrange(SECTIONNAME, group_name) %>%
         rbind(footsum)
-      print(dfDownload)
       write.csv(dfDownload, file, row.names = FALSE)
     }
   )
@@ -356,7 +355,7 @@ server <- function(input, output, session) {
       dfDownload <- dfDownload %>%
         mutate_if(is.numeric, list(~ gsub(" ", "", format(., scientific = FALSE)))) %>%
         mutate_all(list(~ gsub("-10000", "c", .))) %>%
-        mutate_all(list(~ ifelse(. == "NA", "x", .))) %>%
+        mutate_all(list(~ ifelse(. %in% c("NA","NaN"), "x", .))) %>%
         arrange(subject_name) %>%
         rbind(footsum)
       write.csv(dfDownload, file, row.names = FALSE)


### PR DESCRIPTION
The download files were rendering NAs as "NaN" instead of "x" in the download tables, where NAs were created in nested tables (i.e. subject by industry tab).

I've just added NaN as a filter string in the cleaning bit of the download code. Have extended it out to the Industry by Subject tables as well even though they don't have nested elements. Just figure it shouldn't do any harm and it keeps the code consistent (and might come in useful down the road).