### PR TITLE
Updated page title in cookie banner

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -44,7 +44,7 @@ fluidPage(
   ),
   cookie_banner_ui(
     "cookie-banner",
-    "Your dashboard name"
+    "Longitudinal Education Outcomes - Graduate Industry"
   ),
   tags$head(includeHTML(("google-analytics.html"))),
   dfe_cookie_script(),


### PR DESCRIPTION
## Pull request overview

Just spotted that I didn't update the dashboard name field when creating the cookie banner. This is just a quick update to set that straight.